### PR TITLE
Add visible header with integrated theme toggle button

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,56 +10,57 @@
     <link rel="stylesheet" href="style.css?v=10" />
   </head>
   <body>
-    <!-- Theme Toggle Button -->
-    <button
-      type="button"
-      class="theme-toggle"
-      id="themeToggle"
-      aria-label="Toggle dark/light theme"
-      title="Toggle theme"
-    >
-      <svg
-        class="sun-icon"
-        xmlns="http://www.w3.org/2000/svg"
-        width="20"
-        height="20"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <circle cx="12" cy="12" r="5"></circle>
-        <line x1="12" y1="1" x2="12" y2="3"></line>
-        <line x1="12" y1="21" x2="12" y2="23"></line>
-        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-        <line x1="1" y1="12" x2="3" y2="12"></line>
-        <line x1="21" y1="12" x2="23" y2="12"></line>
-        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-      </svg>
-      <svg
-        class="moon-icon"
-        xmlns="http://www.w3.org/2000/svg"
-        width="20"
-        height="20"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-      </svg>
-    </button>
-
     <div class="container">
       <header>
-        <h1>Course Materials Assistant</h1>
-        <p class="subtitle">Ask questions about courses, instructors, and content</p>
+        <div class="header-content">
+          <h1>Course Materials Assistant</h1>
+          <p class="subtitle">Ask questions about courses, instructors, and content</p>
+        </div>
+        <!-- Theme Toggle Button -->
+        <button
+          type="button"
+          class="theme-toggle"
+          id="themeToggle"
+          aria-label="Toggle dark/light theme"
+          title="Toggle theme"
+        >
+          <svg
+            class="sun-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line>
+            <line x1="21" y1="12" x2="23" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+          </svg>
+          <svg
+            class="moon-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+        </button>
       </header>
 
       <div class="main-content">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -49,25 +49,32 @@ body {
   padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-  display: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.header-content {
+  flex: 1;
 }
 
 header h1 {
-  font-size: 1.75rem;
+  font-size: 1.5rem;
   font-weight: 700;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
   margin: 0;
 }
 
 .subtitle {
-  font-size: 0.95rem;
+  font-size: 0.875rem;
   color: var(--text-secondary);
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 /* Main Content Area with Sidebar */
@@ -746,11 +753,20 @@ details[open] .suggested-header::before {
   }
 
   header {
-    padding: 1rem;
+    padding: 0.75rem 1rem;
   }
 
   header h1 {
-    font-size: 1.5rem;
+    font-size: 1.25rem;
+  }
+
+  .subtitle {
+    font-size: 0.75rem;
+  }
+
+  .theme-toggle {
+    width: 40px;
+    height: 40px;
   }
 
   .chat-messages {
@@ -794,22 +810,19 @@ details[open] .suggested-header::before {
 
 /* Theme Toggle Button */
 .theme-toggle {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    z-index: 1000;
     width: 44px;
     height: 44px;
     border-radius: 50%;
     border: 1px solid var(--border-color);
-    background: var(--surface);
+    background: var(--background);
     color: var(--text-primary);
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.3s ease;
-    box-shadow: var(--shadow);
+    flex-shrink: 0;
+    margin-left: 1rem;
 }
 
 .theme-toggle:hover {
@@ -921,14 +934,4 @@ body,
 
 [data-theme="light"] .message-content pre {
     background-color: rgba(0, 0, 0, 0.06);
-}
-
-/* Responsive theme toggle */
-@media (max-width: 768px) {
-    .theme-toggle {
-        top: 0.75rem;
-        right: 0.75rem;
-        width: 40px;
-        height: 40px;
-    }
 }


### PR DESCRIPTION
Fixes #2

This PR adds a visible header to the Course Materials Assistant app.

### Changes
- Made header visible with flexbox layout
- Moved theme toggle button from fixed position into header
- Header includes title, subtitle, and theme button
- Respects theme colors with smooth transitions
- Added responsive styles for mobile devices
- Theme functionality remains fully intact

Generated with [Claude Code](https://claude.ai/code)